### PR TITLE
Use dedicated class for home page thumbnails

### DIFF
--- a/_sass/_posts.scss
+++ b/_sass/_posts.scss
@@ -66,7 +66,7 @@
   }
 }
 
-.post img {
+.post-thumbnail {
   max-height: 240px;   // adjust to taste (e.g., 200px or 180px for tighter layout)
   object-fit: cover;
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ title: Home
     
     <!-- Post image -->
     {% if post.image %}
-    <img src="{{ post.image }}" />
+    <img class="post-thumbnail" src="{{ post.image }}" />
     {% endif %}
     
     <!-- Show an excerpt from the article -->


### PR DESCRIPTION
## Summary
- scope thumbnail styling to a dedicated `.post-thumbnail` class
- add that class to home page post images to avoid affecting in-post images

## Testing
- `gem install jekyll` *(fails: 403 "Forbidden")*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689393a52fa4832a942301dec12c997b